### PR TITLE
Refactor Android implementation to use singleton (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ import Analytics from 'react-native-analytics-segment-io'
 Analytics.setup('segment_write_key', { enableAdvertisingTracking: true })
 ```
 
+*On Android, `setup()` returns a promise to indicate whether the initialization was successful or not.*
+
 Supported options:
 
 | Options                         | Type    | Default | Description                                                                                                                                                                            |

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ export default {
   setup: function (key, options = {}) {
     if (!options.flushAt) options.flushAt = 20
 
-    RNASegmentIO.setup(key, options)
+    return RNASegmentIO.setup(key, options)
   },
 
   identify: function (userId, traits = {}) {


### PR DESCRIPTION
The Segment SDK gets very unhappy when we instantiate a second Analytics object,
so instead, we go back to using the provided singleton. The `setup` method can be
called once to perform the initial setup, and subsequent calls will result in failure.
That will, however, be wrapped in a promise, so it does not crash the app that is
using the module. This means that it is now up to the consumer of the module to
deal with success and failure.

Related to #3 