### PR TITLE
Change dependency on React Native to `peerDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/leoilab/react-native-analytics-segment-io/issues"
   },
   "homepage": "https://github.com/leoilab/react-native-analytics-segment-io#readme",
-  "devDependencies": {
-    "react-native": "^0.47.1"
+  "peerDependencies": {
+    "react-native": ">=0.46.4"
   }
 }


### PR DESCRIPTION
This makes it clear that the module requires React Native, but running `npm|yarn install` in the root will not download RN itself.

Also, while we're at it, change the RN version to the minimum required version.