### PR TITLE
Add a bunch of device-based integrations for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,38 @@ The Segment SDK is added to the library as a `provided` dependency, meaning that
 
 It is required to use React Native v0.46.4 or higher. This is because we use a feature in Java on the passed maps (`.toHashMap()`) that is introduced in that version.
 
+### Device-based integration components
+
+To add an [integration](https://segment.com/docs/sources/mobile/android/#migrating-to-v4) with a Device-based destination, you have to manually add that integration as a dependency to the app's `build.gradle` file.
+
+For example:
+
+```
+compile 'com.segment.analytics.android.integrations:firebase:1.1.0'
+compile 'com.segment.analytics.android.integrations:mixpanel:1.1.0'
+```
+
+The wrapper will automatically register the added components in the configuration when the SDK is present.
+
+Supported integrations:
+
+| Component           | Dependency           |
+|---------------------|----------------------|
+| [AppsFlyer](https://github.com/AppsFlyerSDK/AppsFlyer-Segment-Integration) | `com.appsflyer:segment-android-integration:1.9` |
+| [Adjust](https://github.com/segment-integrations/analytics-android-integration-adjust) | `com.segment.analytics.android.integrations:adjust:0.3.1` |
+| [Amplitude](https://github.com/segment-integrations/analytics-android-integration-amplitude) | `com.segment.analytics.android.integrations:amplitude:1.2.1` |
+| [Bugsnag](https://github.com/segment-integrations/analytics-android-integration-bugsnag) | `com.segment.analytics.android.integrations:bugsnag:1.0.0` |
+| [ComScore](https://github.com/segment-integrations/analytics-android-integration-comscore) | `com.segment.analytics.android.integrations:comscore:3.0.0` |
+| [Countly](https://github.com/segment-integrations/analytics-android-integration-countly) | `com.segment.analytics.android.integrations:countly:1.0.0` |
+| [Crittercism](https://github.com/segment-integrations/analytics-android-integration-crittercism) | `com.segment.analytics.android.integrations:crittercism:1.0.0` |
+| [Firebase](https://github.com/segment-integrations/analytics-android-integration-firebase) | `com.segment.analytics.android.integrations:firebase:1.1.0` |
+| [Google Analytics](https://github.com/segment-integrations/analytics-android-integration-google-analytics) | `com.segment.analytics.android.integrations:google-analytics:2.0.0` |
+| [Localytics](https://github.com/segment-integrations/analytics-android-integration-localytics) | `com.segment.analytics.android.integrations:Localytics` |
+| [Mixpanel](https://github.com/segment-integrations/analytics-android-integration-mixpanel) | `com.segment.analytics.android.integrations:mixpanel:1.1.0` |
+| [NielsenDCR](https://github.com/segment-integrations/analytics-android-integration-nielsendcr) | `com.segment.analytics.android.integrations:nielsendcr:1.0.0-Beta` |
+| [Quantcast](https://github.com/segment-integrations/analytics-android-integration-quantcast) | `com.segment.analytics.android.integrations:quantcast:1.0.1` |
+| [Tapstream](https://github.com/segment-integrations/analytics-android-integration-tapstream) | `com.segment.analytics.android.integrations:tapstream:1.0.0` |
+
 # Usage
 
 ```js

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,9 +26,28 @@ repositories {
   println(rootDir)
   maven { url "$rootDir/../node_modules/react-native/android" }
   mavenCentral()
+  maven { url 'https://comscore.bintray.com/Analytics' } // Required for Comscore
+  maven { url 'http://dl.bintray.com/countly/maven' } // Required for Countly
+  maven { url 'https://maven.google.com' } // Required for Firebase
+  maven { url 'http://maven.localytics.com/public' } // Required for Localytics
 }
 
 dependencies {
   provided 'com.facebook.react:react-native:+'
   provided 'com.segment.analytics.android:analytics:4.2.6'
+
+  provided 'com.appsflyer:segment-android-integration:1.9'
+  provided 'com.segment.analytics.android.integrations:adjust:0.3.1'
+  provided 'com.segment.analytics.android.integrations:amplitude:1.2.1'
+  provided 'com.segment.analytics.android.integrations:bugsnag:1.0.0'
+  provided 'com.segment.analytics.android.integrations:comscore:3.0.0'
+  provided 'com.segment.analytics.android.integrations:countly:1.0.0'
+  provided 'com.segment.analytics.android.integrations:crittercism:1.0.0'
+  provided 'com.segment.analytics.android.integrations:firebase:1.1.0'
+  provided 'com.segment.analytics.android.integrations:google-analytics:2.0.0'
+  provided 'com.segment.analytics.android.integrations:localytics:1.1.0'
+  provided 'com.segment.analytics.android.integrations:mixpanel:1.1.0'
+  provided 'com.segment.analytics.android.integrations:nielsendcr:1.0.0-Beta'
+  provided 'com.segment.analytics.android.integrations:quantcast:1.0.1'
+  provided 'com.segment.analytics.android.integrations:tapstream:1.0.0'
 }

--- a/android/src/main/java/com/leo_pharma/analytics/SegmentModule.java
+++ b/android/src/main/java/com/leo_pharma/analytics/SegmentModule.java
@@ -10,6 +10,20 @@ import com.facebook.react.bridge.ReadableMap;
 import com.segment.analytics.Analytics;
 import com.segment.analytics.Properties;
 import com.segment.analytics.Traits;
+import com.segment.analytics.android.integrations.adjust.AdjustIntegration;
+import com.segment.analytics.android.integrations.amplitude.AmplitudeIntegration;
+import com.segment.analytics.android.integrations.appsflyer.AppsflyerIntegration;
+import com.segment.analytics.android.integrations.bugsnag.BugsnagIntegration;
+import com.segment.analytics.android.integrations.comscore.ComScoreIntegration;
+import com.segment.analytics.android.integrations.countly.CountlyIntegration;
+import com.segment.analytics.android.integrations.crittercism.CrittercismIntegration;
+import com.segment.analytics.android.integrations.firebase.FirebaseIntegration;
+import com.segment.analytics.android.integrations.google.analytics.GoogleAnalyticsIntegration;
+import com.segment.analytics.android.integrations.localytics.LocalyticsIntegration;
+import com.segment.analytics.android.integrations.mixpanel.MixpanelIntegration;
+import com.segment.analytics.android.integrations.nielsendcr.NielsenDCRIntegration;
+import com.segment.analytics.android.integrations.quantcast.QuantcastIntegration;
+import com.segment.analytics.android.integrations.tapstream.TapstreamIntegration;
 
 public class SegmentModule extends ReactContextBaseJavaModule {
     private static final String PROPERTY_FLUSH_AT = "flushAt";
@@ -48,12 +62,93 @@ public class SegmentModule extends ReactContextBaseJavaModule {
             }
         }
 
+        setupIntegrations(analyticsBuilder);
+
         try {
             Analytics.setSingletonInstance(analyticsBuilder.build());
             promise.resolve(true);
         }
         catch (IllegalStateException e) {
             promise.reject("IllegalStateException", "Analytics is already set up, cannot perform setup twice.");
+        }
+    }
+
+    /**
+     * Sets up integrations from https://github.com/segment-integrations plus AppsFlyer, if their SDK is present
+     *
+     * @param analyticsBuilder
+     */
+    private void setupIntegrations(Analytics.Builder analyticsBuilder) {
+        if (isClassAvailable("com.segment.analytics.android.integrations.adjust.AdjustIntegration")) {
+            analyticsBuilder.use(AdjustIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.amplitude.AmplitudeIntegration")) {
+            analyticsBuilder.use(AmplitudeIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.appsflyer.AppsflyerIntegration")) {
+            analyticsBuilder.use(AppsflyerIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.bugsnag.BugsnagIntegration")) {
+            analyticsBuilder.use(BugsnagIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.comscore.ComScoreIntegration")) {
+            analyticsBuilder.use(ComScoreIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.countly.CountlyIntegration")) {
+            analyticsBuilder.use(CountlyIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.crittercism.CrittercismIntegration")) {
+            analyticsBuilder.use(CrittercismIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.firebase.FirebaseIntegration")) {
+            analyticsBuilder.use(FirebaseIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.google.analytics.GoogleAnalyticsIntegration")) {
+            analyticsBuilder.use(GoogleAnalyticsIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.localytics.LocalyticsIntegration")) {
+            analyticsBuilder.use(LocalyticsIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.mixpanel.MixpanelIntegration")) {
+            analyticsBuilder.use(MixpanelIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.nielsendcr.NielsenDCRIntegration")) {
+            analyticsBuilder.use(NielsenDCRIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.quantcast.QuantcastIntegration")) {
+            analyticsBuilder.use(QuantcastIntegration.FACTORY);
+        }
+
+        if (isClassAvailable("com.segment.analytics.android.integrations.tapstream.TapstreamIntegration")) {
+            analyticsBuilder.use(TapstreamIntegration.FACTORY);
+        }
+    }
+
+    /**
+     * Checks if a certain class is available.
+     *
+     * @param className Including the full package name
+     * @return True if the class is available. False if it cannot be found.
+     */
+    private boolean isClassAvailable(String className) {
+        try {
+            Class.forName(className);
+            return true;
+        }
+        catch (ClassNotFoundException e) {
+            return false;
         }
     }
 


### PR DESCRIPTION
Taken from the list of integrations on https://github.com/segment-integrations plus AppsFlyer.
Including documentation on which integrations are available and how to set them up.