### PR TITLE
Add debug option to setup to log during development

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Supported options:
 | trackApplicationLifecycleEvents | Bool    | `false` | Whether the analytics client should automatically make a track call for application lifecycle events, such as "Application Installed", "Application Updated" and "Application Opened". |
 | trackAttributionData            | Bool    | `false` | Whether the analytics client should automatically track attribution data from enabled providers using the mobile service.                                                              |
 | trackDeepLinks                  | Bool    | `false` | Whether the analytics client should automatically track deep links.                                                                                                                    |
+| debug                           | Bool    | `false` | Whether the analytics client should log everything to the console (only enable this during development).                                                                               |
 
 ## identify: function (userId, traits = {})
 *Tie a user to their actions and record traits about them*

--- a/android/src/main/java/com/leo_pharma/analytics/SegmentModule.java
+++ b/android/src/main/java/com/leo_pharma/analytics/SegmentModule.java
@@ -31,6 +31,7 @@ public class SegmentModule extends ReactContextBaseJavaModule {
     private static final String PROPERTY_RECORD_SCREEN_VIEWS = "recordScreenViews";
     private static final String PROPERTY_TRACK_APPLICATION_LIFECYCLE_EVENTS = "trackApplicationLifecycleEvents";
     private static final String PROPERTY_TRACK_ATTRIBUTION_DATA = "trackAttributionData";
+    private static final String PROPERTY_DEBUG = "debug";
 
     public SegmentModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -62,6 +63,13 @@ public class SegmentModule extends ReactContextBaseJavaModule {
             if (options.hasKey(PROPERTY_TRACK_ATTRIBUTION_DATA)
                     && options.getBoolean(PROPERTY_TRACK_ATTRIBUTION_DATA)) {
                 analyticsBuilder.trackAttributionInformation();
+            }
+
+            if (options.hasKey(PROPERTY_DEBUG) && options.getBoolean(PROPERTY_DEBUG)) {
+                analyticsBuilder.logLevel(Analytics.LogLevel.VERBOSE);
+            }
+            else {
+                analyticsBuilder.logLevel(Analytics.LogLevel.NONE);
             }
         }
 
@@ -113,8 +121,7 @@ public class SegmentModule extends ReactContextBaseJavaModule {
             analyticsBuilder.use(FirebaseIntegration.FACTORY);
         }
 
-        if (isClassAvailable(
-                "com.segment.analytics.android.integrations.google.analytics.GoogleAnalyticsIntegration")) {
+        if (isClassAvailable("com.segment.analytics.android.integrations.google.analytics.GoogleAnalyticsIntegration")) {
             analyticsBuilder.use(GoogleAnalyticsIntegration.FACTORY);
         }
 
@@ -141,7 +148,6 @@ public class SegmentModule extends ReactContextBaseJavaModule {
         if (isClassAvailable("com.segment.analytics.android.integrations.branch.BranchIntegration")) {
             analyticsBuilder.use(BranchIntegration.FACTORY);
         }
-
     }
 
     /**

--- a/example/example.js
+++ b/example/example.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import {
-  AppRegistry,
   StyleSheet,
   Text,
   View
@@ -9,7 +8,7 @@ import Analytics from 'react-native-analytics-segment-io';
 
 export default class example extends Component {
   componentDidMount() {
-    Analytics.setup('add-segment-key-here', { enableAdvertisingTracking: true })
+    Analytics.setup('add-segment-key-here', { enableAdvertisingTracking: true, debug: true })
       .then(() => {
         Analytics.track('test', {})
       })

--- a/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
+++ b/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
@@ -132,7 +132,12 @@ RCT_EXPORT_METHOD(setup:(NSString *)key
 #endif
 
     [SEGAnalytics setupWithConfiguration:config];
-    [SEGAnalytics debug:[RCTConvert BOOL:options[@"debug"]]];
+
+    value = options[@"debug"];
+    if (value != nil) {
+        [SEGAnalytics debug:[RCTConvert BOOL:value]];
+    }
+
     resolve(@(YES));
 }
 

--- a/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
+++ b/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
@@ -100,6 +100,7 @@ RCT_EXPORT_METHOD(setup:(NSString *)key
 #endif
 
     [SEGAnalytics setupWithConfiguration:config];
+    [SEGAnalytics debug:[RCTConvert BOOL:options[@"debug"]]];
     resolve(@(YES));
 }
 


### PR DESCRIPTION
It's nice to log to the console/logcat while developing, to verify that
everything works as expected. You can just pass `debug` as one of the
elements in the options map, and (if set to `true`) it will set the
log level to `VERBOSE` on Android and the `debug` flag to `YES` on iOS.

This is not logging in the JavaScript console, but the iOS dev console
and Android's logcat (just to make this perfectly clear).