### PR TITLE
iOS: Prevent default values to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Supported options:
 
 | Options                         | Type    | Default | Description                                                                                                                                                                            |
 |---------------------------------|---------|---------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| enableAdvertisingTracking       | Bool    | `false` | Whether the analytics client should track advertisting info.                                                                                                                           |
+| enableAdvertisingTracking       | Bool    | `true` | Whether the analytics client should track advertisting info.                                                                                                                           |
 | flushAt                         | Integer | `20`    | The number of queued events that the analytics client should flush at. Setting this to `1` will not queue any events and will use more battery.                                        |
 | recordScreenViews               | Bool    | `false` | Whether the analytics client should automatically make a screen call when a view controller is added to a view hierarchy.                                                              |
 | shouldUseBluetooth              | Bool    | `false` | Whether the analytics client should record bluetooth information.                                                                                                                      |

--- a/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
+++ b/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
@@ -34,14 +34,46 @@ RCT_EXPORT_METHOD(setup:(NSString *)key
                   reject:(RCTPromiseRejectBlock)reject)
 {
     SEGAnalyticsConfiguration *config = [SEGAnalyticsConfiguration configurationWithWriteKey:key];
-    config.enableAdvertisingTracking = [RCTConvert BOOL:options[@"enableAdvertisingTracking"]];
-    config.flushAt = [RCTConvert NSUInteger:options[@"flushAt"]];
-    config.recordScreenViews = [RCTConvert BOOL:options[@"recordScreenViews"]];
-    config.shouldUseBluetooth = [RCTConvert BOOL:options[@"shouldUseBluetooth"]];
-    config.shouldUseLocationServices = [RCTConvert BOOL:options[@"shouldUseLocationServices"]];
-    config.trackApplicationLifecycleEvents = [RCTConvert BOOL:options[@"trackApplicationLifecycleEvents"]];
-    config.trackAttributionData = [RCTConvert BOOL:options[@"trackAttributionData"]];
-    config.trackDeepLinks = [RCTConvert BOOL:options[@"trackDeepLinks"]];
+
+    id value = options[@"enableAdvertisingTracking"];
+    if (value != nil) {
+        config.enableAdvertisingTracking = [RCTConvert BOOL:value];
+    }
+
+    value = options[@"flushAt"];
+    if (value != nil) {
+        config.flushAt = [RCTConvert NSUInteger:value];
+    }
+
+    value = options[@"recordScreenViews"];
+    if (value != nil) {
+        config.recordScreenViews = [RCTConvert BOOL:value];
+    }
+
+    value = options[@"shouldUseBluetooth"];
+    if (value != nil) {
+        config.shouldUseBluetooth = [RCTConvert BOOL:value];
+    }
+
+    value = options[@"shouldUseLocationServices"];
+    if (value != nil) {
+        config.shouldUseLocationServices = [RCTConvert BOOL:value];
+    }
+
+    value = options[@"trackApplicationLifecycleEvents"];
+    if (value != nil) {
+        config.trackApplicationLifecycleEvents = [RCTConvert BOOL:value];
+    }
+
+    value = options[@"trackAttributionData"];
+    if (value != nil) {
+        config.trackAttributionData = [RCTConvert BOOL:value];
+    }
+
+    value = options[@"trackDeepLinks"];
+    if (value != nil) {
+        config.trackDeepLinks = [RCTConvert BOOL:value];
+    }
 
 #ifdef SEGTaplyticsIntegrationFactoryImported
     [config use:[SEGTaplyticsIntegrationFactory instance]];


### PR DESCRIPTION
The current implementation overrides default values if the key is not passed.
As an example `flushAt` default value is `20` but if the user doesn't pass that key it will be overridden and turned into `0` as `[RCTConvert NSUInteger:nil]` returns `0`.