### PR TITLE
[WIP] Return promise from native module on all calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,13 @@ import Analytics, { AnalyticsConstants } from 'react-native-analytics-segment-io
 - **Analytics.enable()**
 - **Analytics.disable()**
 
+All functions return a promise to indicate whether the initialization was successful or not.
+
 ## setup: function (key, options = {})
 *Initial framework setup*
 ```js
 Analytics.setup('segment_write_key', { [AnalyticsConstants.enableAdvertisingTracking]: true })
 ```
-
-*`setup()` returns a promise to indicate whether the initialization was successful or not.*
 
 Supported options:
 

--- a/android/src/main/java/com/leo_pharma/analytics/SegmentModule.java
+++ b/android/src/main/java/com/leo_pharma/analytics/SegmentModule.java
@@ -174,62 +174,98 @@ public class SegmentModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void identify(@Nullable String userId, @Nullable ReadableMap properties) {
+    public void identify(@Nullable String userId, @Nullable ReadableMap properties, Promise promise) {
+        Traits traits = new Traits();
+
+        if (properties != null) {
+            traits.putAll(properties.toHashMap());
+        }
+        try {
+
+            Analytics.with(getReactApplicationContext()).identify(userId, traits, null);
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("Exception", e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void track(@Nullable String event, @Nullable ReadableMap properties, Promise promise) {
+        Properties segmentProperties = new Properties();
+
+        if (properties != null) {
+            segmentProperties.putAll(properties.toHashMap());
+        }
+        try {
+
+            Analytics.with(getReactApplicationContext()).track(event, segmentProperties);
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("Exception", e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void screen(@Nullable String name, @Nullable ReadableMap properties, Promise promise) {
+        Properties segmentProperties = new Properties();
+
+        if (properties != null) {
+            segmentProperties.putAll(properties.toHashMap());
+        }
+        try {
+
+            Analytics.with(getReactApplicationContext()).screen("", name, segmentProperties);
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("Exception", e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void group(@Nullable String groupId, @Nullable ReadableMap properties, Promise promise) {
         Traits traits = new Traits();
 
         if (properties != null) {
             traits.putAll(properties.toHashMap());
         }
 
-        Analytics.with(getReactApplicationContext()).identify(userId, traits, null);
+        try {
+            Analytics.with(getReactApplicationContext()).group(groupId, traits, null);
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("Exception", e.getMessage());
+        }
     }
 
     @ReactMethod
-    public void track(@Nullable String event, @Nullable ReadableMap properties) {
-        Properties segmentProperties = new Properties();
+    public void alias(@Nullable String newId, Promise promise) {
+        try {
+            Analytics.with(getReactApplicationContext()).alias(newId);
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("Exception", e.getMessage());
+        }
+    }
 
-        if (properties != null) {
-            segmentProperties.putAll(properties.toHashMap());
+    @ReactMethod
+    public void reset(Promise promise) {
+        try {
+            Analytics.with(getReactApplicationContext()).reset();
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("Exception", e.getMessage());
         }
 
-        Analytics.with(getReactApplicationContext()).track(event, segmentProperties);
     }
 
     @ReactMethod
-    public void screen(@Nullable String name, @Nullable ReadableMap properties) {
-        Properties segmentProperties = new Properties();
-
-        if (properties != null) {
-            segmentProperties.putAll(properties.toHashMap());
+    public void flush(Promise promise) {
+        try {
+            Analytics.with(getReactApplicationContext()).flush();
+            promise.resolve(true);
+        } catch (Exception e) {
+            promise.reject("Exception", e.getMessage());
         }
-
-        Analytics.with(getReactApplicationContext()).screen("", name, segmentProperties);
-    }
-
-    @ReactMethod
-    public void group(@Nullable String groupId, @Nullable ReadableMap properties) {
-        Traits traits = new Traits();
-
-        if (properties != null) {
-            traits.putAll(properties.toHashMap());
-        }
-
-        Analytics.with(getReactApplicationContext()).group(groupId, traits, null);
-    }
-
-    @ReactMethod
-    public void alias(@Nullable String newId) {
-        Analytics.with(getReactApplicationContext()).alias(newId);
-    }
-
-    @ReactMethod
-    public void reset() {
-        Analytics.with(getReactApplicationContext()).reset();
-    }
-
-    @ReactMethod
-    public void flush() {
-        Analytics.with(getReactApplicationContext()).flush();
     }
 
     @Nullable

--- a/index.js
+++ b/index.js
@@ -8,39 +8,39 @@ export default {
   },
 
   identify: function (userId, traits = {}) {
-    RNASegmentIO.identify(userId, traits)
+    return RNASegmentIO.identify(userId, traits)
   },
 
   track: function (event, properties = {}) {
-    RNASegmentIO.track(event, properties)
+    return RNASegmentIO.track(event, properties)
   },
 
   screen: function (name, properties = {}) {
-    RNASegmentIO.screen(name, properties)
+    return RNASegmentIO.screen(name, properties)
   },
 
   group: function (groupId, traits = {}) {
-    RNASegmentIO.group(groupId, traits)
+    return RNASegmentIO.group(groupId, traits)
   },
 
   alias: function (newId) {
-    RNASegmentIO.alias(newId)
+    return RNASegmentIO.alias(newId)
   },
 
   reset: function () {
-    RNASegmentIO.reset()
+    return RNASegmentIO.reset()
   },
 
   flush: function () {
-    RNASegmentIO.flush()
+    return RNASegmentIO.flush()
   },
 
   enable: function () {
-    RNASegmentIO.enable()
+    return RNASegmentIO.enable()
   },
 
   disable: function () {
-    RNASegmentIO.disable()
+    return RNASegmentIO.disable()
   }
 }
 

--- a/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
+++ b/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
@@ -155,49 +155,95 @@ RCT_EXPORT_METHOD(setup:(NSString *)key
     resolve(@(YES));
 }
 
-RCT_EXPORT_METHOD(identify:(NSString *)userId :(NSDictionary *)traits)
+RCT_EXPORT_METHOD(identify:(NSString *)userId :(NSDictionary *)traits resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] identify:userId traits:traits];
+    @try {
+        [[SEGAnalytics sharedAnalytics] identify:userId traits:traits];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
-RCT_EXPORT_METHOD(track:(NSString *)event properties:(NSDictionary *)properties)
+RCT_EXPORT_METHOD(track:(NSString *)event properties:(NSDictionary *)properties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] track:event properties:properties];
+    @try {
+        [[SEGAnalytics sharedAnalytics] track:event properties:properties];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
+    
 }
 
-RCT_EXPORT_METHOD(screen:(NSString *)name :(NSDictionary *)properties)
+RCT_EXPORT_METHOD(screen:(NSString *)name :(NSDictionary *)properties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] screen:name properties:properties];
+    @try {
+        [[SEGAnalytics sharedAnalytics] screen:name properties:properties];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
-RCT_EXPORT_METHOD(group:(NSString *)groupId :(NSDictionary *)traits)
+RCT_EXPORT_METHOD(group:(NSString *)groupId :(NSDictionary *)traits resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] group:groupId traits:traits];
+    @try {
+        [[SEGAnalytics sharedAnalytics] group:groupId traits:traits];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
-RCT_EXPORT_METHOD(alias:(NSString *)newId)
+RCT_EXPORT_METHOD(alias:(NSString *)newId resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] alias:newId];
+    @try {
+        [[SEGAnalytics sharedAnalytics] alias:newId];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
-RCT_EXPORT_METHOD(reset)
+RCT_EXPORT_METHOD(reset:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] reset];
+    @try {
+        [[SEGAnalytics sharedAnalytics] reset];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
-RCT_EXPORT_METHOD(flush)
+RCT_EXPORT_METHOD(flush:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] flush];
+    @try {
+        [[SEGAnalytics sharedAnalytics] flush];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
-RCT_EXPORT_METHOD(enable)
+RCT_EXPORT_METHOD(enable:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] enable];
+    @try {
+        [[SEGAnalytics sharedAnalytics] enable];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
-RCT_EXPORT_METHOD(disable)
+RCT_EXPORT_METHOD(disable:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
-    [[SEGAnalytics sharedAnalytics] disable];
+    @try {
+        [[SEGAnalytics sharedAnalytics] disable];
+        resolve(@YES);
+    } @catch (NSException *e) {
+        reject(e.name, e.reason, nil);
+    }
 }
 
 - (NSDictionary<NSString *, id> *)constantsToExport {


### PR DESCRIPTION
To avoid application crashes when trying to track events or screens, before Segment is initialized, we need to catch these exceptions and let JS handle the errors using a returned promise.

Example:
```js
    Segment.screen(event)
      .then(result => {
        console.log(result) // true
      })
      .catch(error => {
        console.error(error)
      })
```

TODO:

- [ ] Maybe adjust exception levels on Android.