### PR TITLE
Fix for 'Application installed not being tracked' #40 (iOS)

### DIFF
--- a/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
+++ b/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
@@ -24,6 +24,10 @@
 #import "RNASegmentIO.h"
 #import "RNAIntegrations.h"
 
+#import "SEGAnalytics.h"
+
+#import <React/RCTBridge.h>
+
 static NSString * const kSEGEnableAdvertisingTrackingKey = @"enableAdvertisingTracking";
 static NSString * const kSEGFlushAtKey = @"flushAt";
 static NSString * const kSEGRecordScreenViewsKey = @"recordScreenViews";
@@ -37,6 +41,8 @@ static NSString * const kSEGDebugKey = @"debug";
 @implementation RNASegmentIO
 
 RCT_EXPORT_MODULE()
+
+@synthesize bridge = _bridge;
 
 RCT_EXPORT_METHOD(setup:(NSString *)key
                   options:(NSDictionary *)options
@@ -154,6 +160,14 @@ RCT_EXPORT_METHOD(setup:(NSString *)key
     value = options[kSEGDebugKey];
     if (value != nil) {
         [SEGAnalytics debug:[RCTConvert BOOL:value]];
+    }
+    //Fix due to late init of native module
+    value = options[kSEGTrackApplicationLifecycleEventsKey];
+    if (value != nil && [RCTConvert BOOL:value]) {
+        SEL selector = @selector(_applicationDidFinishLaunchingWithOptions:);
+        if ([[SEGAnalytics sharedAnalytics] respondsToSelector:selector]) {
+            [[SEGAnalytics sharedAnalytics] performSelector:selector withObject:self.bridge.launchOptions];
+        }
     }
 
     resolve(@(YES));


### PR DESCRIPTION
Opening this as a means to get feedback and start a discussion. 

I'm currently leaning towards initializing Segment (natively) outside of React Native, because the issue is not only limited to Application open and Install events not being tracked because they trigger before `setup` but also other things such as attribution tracking and possibly notification open (Haven't checked this yet).

My current temporary fix to the problem on iOS is basically calling `_applicationDidFinishLaunchingWithOptions` from the Segment iOS library upon setup. If it's possible to call the library function without a modification to it, I'd appreciate any help on this as I'm really not familiar with Objective-c. Currently I've pretty much copied the code with little to no modification.

I've noticed the issue also exists on Android and a similar fix could be made by either fork or commit upstream such that `trackApplicationLifecycleEvents()` isn't private, but this would again require doing the same to other methods being called onActivityCreated such as `trackAttributionInformation`.

All of this could of course also be implemented on the JS side of things, but I'm not sure it's worth it in terms of maintainability.

**Better solution:**?

We could instead add segment setup options and keys to `package.json` and or `.env` and as a build step make the options available in the native code, similar to how [react-native-config](https://github.com/luggit/react-native-config) does it.

Shorter term solution would be to explicitly pass in the configs after `react-native link`:
`new AnalyticsPackage(/* add settings here*/)`

p.s. let me know if you prefer that I move this discussion to the existing github issue instead.