### PR TITLE
Update segment-android dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ repositories {
 
 dependencies {
   provided 'com.facebook.react:react-native:+'
-  provided 'com.segment.analytics.android:analytics:4.2.6'
+  provided 'com.segment.analytics.android:analytics:4.3.1'
 
   provided 'com.appboy:appboy-segment-integration:2.1.1'
   provided 'com.appsflyer:segment-android-integration:1.9'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
 
-    compile 'com.segment.analytics.android:analytics:4.2.6'
+    compile 'com.segment.analytics.android:analytics:4.3.1'
     compile project(':react-native-analytics-segment-io')
 }
 


### PR DESCRIPTION
This PR updates the segment-android dependency as the version 4.2.6 has `attribution tracking` on by default, not allowing the consumer of the API to change it. It also throws an error when the facilities for attribution tracking isn't enabled: https://github.com/segmentio/analytics-android/issues/532