### PR TITLE
Fix rogue import in iOS module

### DIFF
--- a/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
+++ b/ios/RNAnalyticsSegmentIO/RNASegmentIO.m
@@ -24,8 +24,6 @@
 #import "RNASegmentIO.h"
 #import "RNAIntegrations.h"
 
-#import "SEGAnalytics.h"
-
 #import <React/RCTBridge.h>
 
 static NSString * const kSEGEnableAdvertisingTrackingKey = @"enableAdvertisingTracking";


### PR DESCRIPTION
The import was causing issues on release builds (but not on debug builds). It doesn't need to be there, so we can just remove it.