### PR TITLE
Compatibility fix with RN-0.46.4

### DIFF
--- a/android/src/main/java/com/leo_pharma/analytics/AnalyticsPackage.java
+++ b/android/src/main/java/com/leo_pharma/analytics/AnalyticsPackage.java
@@ -1,6 +1,7 @@
 package com.leo_pharma.analytics;
 
 import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -10,6 +11,11 @@ import java.util.Collections;
 import java.util.List;
 
 public class AnalyticsPackage implements ReactPackage {
+     
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
+    }
+    
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();


### PR DESCRIPTION
Adds createJSModules required by RN < 47.
But without @override so it's compatible with RN > 47 See: facebook/react-native@ce6fb33