### PR TITLE
Add import path to manual Android setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ compile 'com.segment.analytics.android:analytics:x.x.x' // We have tested with v
 
 Then sync Gradle, and add the analytics package to your `Application` class:
 ```java
+import com.leo_pharma.analytics.AnalyticsPackage;
+...
 @Override
 protected List<ReactPackage> getPackages() {
   return Arrays.<ReactPackage>asList(


### PR DESCRIPTION
Addresses https://github.com/leoilab/react-native-analytics-segment-io/issues/59

It's difficult to say how many are afflicted by this. But if the automatic link fails, it's nice to have the documentation clear.