### PR TITLE
Pull android tool versions from root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,13 +10,19 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
+
 android {
-  compileSdkVersion 25
-  buildToolsVersion '25.0.2'
+  compileSdkVersion safeExtGet('compileSdkVersion', 25)
+  buildToolsVersion safeExtGet('buildToolsVersion', '25.0.2')
 
   defaultConfig {
-    minSdkVersion 16
-    targetSdkVersion 22
+    minSdkVersion safeExtGet('minSdkVersion', 16)
+    targetSdkVersion safeExtGet('targetSdkVersion', 22)
     versionCode 1
     versionName '1.0'
   }


### PR DESCRIPTION
If the host react native application is using a different version of the android sdk build tools, build warnings will be displayed about incompatibilities. This addresses that by using the values defined in the root project.

This is the approach used by the current [react-native-create-library template](https://github.com/frostney/react-native-create-library/blob/master/templates/android.js#L28).